### PR TITLE
fix(ios): prevent crash in saveFailedUpdate when server returns null fields

### DIFF
--- a/ios/CodePush/CodePush.m
+++ b/ios/CodePush/CodePush.m
@@ -583,7 +583,19 @@ static NSString *const LatestRollbackCountKey = @"count";
     if ([[self class] isFailedHash:[failedPackage objectForKey:PackageHashKey]]) {
         return;
     }
-    
+
+    // The server may return null for optional fields (e.g. assetDownloadUrl,
+    // bundleDiffBlobUrl), which NSJSONSerialization parses to NSNull. NSNull
+    // is not a property list type, so passing it to NSUserDefaults raises
+    // NSInvalidArgumentException ("Attempt to insert non-property list object").
+    NSMutableDictionary *sanitizedPackage = [NSMutableDictionary dictionaryWithCapacity:failedPackage.count];
+    for (NSString *key in failedPackage) {
+        id value = failedPackage[key];
+        if (value && ![value isKindOfClass:[NSNull class]]) {
+            sanitizedPackage[key] = value;
+        }
+    }
+
     NSUserDefaults *preferences = [NSUserDefaults standardUserDefaults];
     NSMutableArray *failedUpdates = [preferences objectForKey:FailedUpdatesKey];
     if (failedUpdates == nil) {
@@ -594,9 +606,18 @@ static NSString *const LatestRollbackCountKey = @"count";
         failedUpdates = [failedUpdates mutableCopy];
     }
 
-    [failedUpdates addObject:failedPackage];
-    [preferences setObject:failedUpdates forKey:FailedUpdatesKey];
-    [preferences synchronize];
+    [failedUpdates addObject:sanitizedPackage];
+    @try {
+        [preferences setObject:failedUpdates forKey:FailedUpdatesKey];
+        [preferences synchronize];
+    } @catch (NSException *exception) {
+        // Defensive: if a future server response shape slips through the filter,
+        // clear the corrupt list so the app does not crash on every subsequent
+        // launch via initializeUpdateAfterRestart -> rollbackPackage.
+        CPLog(@"Failed to persist failed update list: %@. Clearing key.", exception);
+        [preferences removeObjectForKey:FailedUpdatesKey];
+        [preferences synchronize];
+    }
 }
 
 /*


### PR DESCRIPTION
## Problem

`-[CodePush saveFailedUpdate:]` crashes the app on iOS with `NSInvalidArgumentException` when the failed package metadata contains `NSNull` values for optional fields:

```
Fatal Exception: NSInvalidArgumentException
Attempt to insert non-property list object ( {
    appVersion = "1.6.0";
    assetDownloadUrl = "<null>";
    binaryDate = "1776900944.000000";
    bundleDiffBlobUrl = "<null>";
    bundlePath = "revopush_package.../main.jsbundle";
    deploymentKey = ...;
    description = "";
    downloadUrl = "https://blob.revopush.org/...";
    failedInstall = 0;
    isMandatory = 0;
    isPending = 0;
    label = v13;
    packageHash = ...;
    packageSize = 11773151;
} ) for key CODE_PUSH_FAILED_UPDATES
```

### Root cause

The package metadata is built from the server response via `NSJSONSerialization`. JSON `null` is parsed as `NSNull`. When `saveFailedUpdate:` writes the dictionary to `NSUserDefaults`, `_CFPrefsValidateValueForKey` rejects `NSNull` (only `NSString` / `NSNumber` / `NSDate` / `NSArray` / `NSDictionary` / `NSData` are valid property-list types) and throws `NSInvalidArgumentException`. The exception is uncaught and aborts the process.

In the field this triggers for fields like `assetDownloadUrl` and `bundleDiffBlobUrl`, which the server emits as \`null\` when no asset/diff URL is registered for the failed package.

### When it fires

\`saveFailedUpdate:\` is invoked from \`-[CodePush init]\` via \`initializeUpdateAfterRestart\` -> \`rollbackPackage\` (when a previous update was marked \`isLoading=YES\` and never confirmed via \`notifyApplicationReady\`). This runs during \`RCTTurboModuleManager\` instantiation, before any JS executes - so the app crashes on launch, every launch, until the corrupt state is cleared by an uninstall + reinstall.

### Related history

This is a recurrence of [microsoft/react-native-code-push#493](https://github.com/microsoft/react-native-code-push/issues/493) (fixed by [PR #497](https://github.com/microsoft/react-native-code-push/pull/497)) and [#606](https://github.com/microsoft/react-native-code-push/issues/606). Those fixes only nil-checked the dictionary itself; they did not strip \`NSNull\` values from inside the dictionary, so the underlying bug was never fully addressed.

## Fix

Two layers in \`saveFailedUpdate:\`:

1. **Sanitize the dictionary** - copy \`failedPackage\` into an \`NSMutableDictionary\`, dropping any value that is \`NSNull\` (or \`nil\`). This handles the documented current crash (\`assetDownloadUrl\`, \`bundleDiffBlobUrl\`).
2. **Defensive \`@try/@catch\`** - if a future server-response shape introduces a non-plist value the filter doesn't catch, log it and clear \`CODE_PUSH_FAILED_UPDATES\` so subsequent launches don't crash on every \`initializeUpdateAfterRestart\` run. Worst-case behavior degrades to \"the broken update may be retried once\" instead of \"the app is bricked until reinstall\".

The dictionary stored in \`failedUpdates\` is only consumed by \`+isFailedHash:\`, which reads \`packageHash\` (always an \`NSString\`, never null). Dropping the URL/diff fields has no functional impact.

## Verification

Reproduced on iOS 26 / iPhone 13 mini against a deployment whose manifest contained \`null\` for \`assetDownloadUrl\` and \`bundleDiffBlobUrl\`. Before the fix: 100% crash on the second launch after a fresh install (first launch downloads the OTA, app is killed before \`notifyApplicationReady\`, second launch enters the rollback path and crashes in \`saveFailedUpdate:\`). After the fix: rollback completes cleanly and the app falls back to the binary bundle.